### PR TITLE
Temp work around to include hash with results. I've only done this for t...

### DIFF
--- a/application/registry.py
+++ b/application/registry.py
@@ -28,6 +28,9 @@ class Register(Entry):
         registers[collection] = self
         Entry.__init__(self, name=name, *args, **kwargs)
 
+    def put(self, entry):
+        self._store.put(entry)
+
     # TBD: move to entry store / representations
     def load(self, path):
         for root, dirs, files in os.walk(path):
@@ -60,7 +63,7 @@ class Register(Entry):
                     elif suffix == ".json":
                         entry.json = text
 
-                    self._store.put(entry)
+                    self.put(entry)
 
     def load_remote(self, url):
         try:
@@ -80,7 +83,7 @@ class Register(Entry):
                     if name.endswith('.yaml'):
                         entry = Entry()
                         entry.yaml = file_contents.read()
-                        self._store.put(entry)
+                        self.put(entry)
                     elif name.endswith('.tsv'):
                         reader = csv.DictReader(file_contents, delimiter='\t')
                         for row in reader:

--- a/application/templates/entries.html
+++ b/application/templates/entries.html
@@ -46,7 +46,7 @@
                   {% endif %}
                 </th>
               {% endfor %}
-              </tr>
+              <th>hash</th>
               </tr>
             </thead>
 
@@ -57,6 +57,7 @@
               {% for key in entry_keys %}
                 <td class="{{ key }}">{{ entry[key]|datatype(key) }}</td>
               {% endfor %}
+                <td class="hash">{{hash}}</td>
               </tr>
               {% endfor %}
 


### PR DESCRIPTION
@jakobgrunig or @psd let's try again. This is a temporary 'fix' to include hash for clients to api. This only affects json responses (html response already included this). The proper fix would be a change to Entry.